### PR TITLE
Get LDAP working with Active Directory

### DIFF
--- a/cobbler/modules/authentication/ldap.py
+++ b/cobbler/modules/authentication/ldap.py
@@ -65,6 +65,9 @@ def authenticate(api_handle, username, password):
     else:
         servers = [server]
 
+    # to get ldap working with Active Directory
+    ldap.set_option(ldap.OPT_REFERRALS, 0)
+    
     if tls_cacertfile:
         ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, tls_cacertfile)
     if tls_keyfile:


### PR DESCRIPTION
To fix active directory authentication error as described here:
https://stackoverflow.com/questions/140439/authenticating-against-active-directory-using-python-ldap
("ldap.OPERATIONS_ERROR")

Per python-ldap:
https://www.python-ldap.org/en/latest/faq.html
"Q: My script bound to MS Active Directory but a a search operation results in the exception ldap.OPERATIONS_ERROR with the diagnostic message text “In order to perform this operation a successful bind must be completed on the connection.” Alternatively, a Samba 4 AD returns the diagnostic message “Operation unavailable without authentication”. What’s happening here?

A: When searching from the domain level, MS AD returns referrals (search continuations) for some objects to indicate to the client where to look for these objects. Client-chasing of referrals is a broken concept, since LDAPv3 does not specify which credentials to use when chasing the referral. Windows clients are supposed to simply use their Windows credentials, but this does not work in general when chasing referrals received from and pointing to arbitrary LDAP servers.

Therefore, per default, libldap automatically chases the referrals internally with an anonymous access which fails with MS AD.

So, the best thing to do is to switch this behaviour off"